### PR TITLE
Fix Spanish translation in site slogan

### DIFF
--- a/src/config/content.js
+++ b/src/config/content.js
@@ -6,7 +6,7 @@ export default {
     "¿Qué sabes sobre React? o ¿Qué puedes contarme de Arquitectura de Software?",
   placeholderChat2: "Quiero recursos sobre...",
   siteSlogan:
-    "Buscador powerizado por la IA de GPT y el contenido del podcast Web Reactiva y la newsletter Reactivísima",
+    "Buscador potenciado por la IA de GPT y el contenido del podcast Web Reactiva y la newsletter Reactivísima",
   loadingText: "Circuitos cerebrales calculando respuesta ...",
   loadingText2: "Circuitos cerebrales conectando nainonaaa...",
   chatResponseTitle: "Robotito dice:",


### PR DESCRIPTION
## Summary
- fix a Spanish typo in the site slogan

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_683fee975d88832e9ae426916800c351